### PR TITLE
fix: keep data_root offline + clearer launch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ GitHub Release notes should match these bullets.
 - Vorgang tab: Schritte/Live no longer overlap; OK/FAIL rows appear in Schritte
 - Header health chip text no longer clipped (e.g. “4 Hinweise”)
 - Window icon: opaque anthracite PNG/ICO (no white corners in title bars)
+- Keep relocated data_root.path when the target disk is temporarily unmounted
+- Launch dialog: show real script errors (missing EXE) instead of “not active after launch”
 
 ## [1.1.42] - 2026-08-12
 

--- a/core/recipe.sh
+++ b/core/recipe.sh
@@ -37,7 +37,20 @@ recipe_export_env() {
             fi
         fi
         if [ "$persist" -eq 1 ] && [ -n "$chosen" ]; then
-            printf '%s\n' "$chosen" >"$canonical/data_root.path"
+            # Don't overwrite a relocated pointer with the YAML canonical path when
+            # the real target is only temporarily offline (unmounted disk). The GUI
+            # falls back to canonical for that run; the pointer must survive.
+            if [ -f "$canonical/data_root.path" ]; then
+                existing="$(tr -d '\r\n' <"$canonical/data_root.path" 2>/dev/null || true)"
+                existing="$(paths_expand "${existing:-}")"
+                if [ -n "$existing" ] && [ "$existing" != "$chosen" ] \
+                    && [ "$chosen" = "$canonical" ]; then
+                    persist=0
+                fi
+            fi
+            if [ "$persist" -eq 1 ]; then
+                printf '%s\n' "$chosen" >"$canonical/data_root.path"
+            fi
         fi
     elif [ -f "$canonical/data_root.path" ]; then
         chosen="$(tr -d '\r\n' <"$canonical/data_root.path")"

--- a/launcher/locales/de.json
+++ b/launcher/locales/de.json
@@ -621,6 +621,8 @@
     "launch_already": "„{name}“ lief bereits (evtl. unsichtbar) — Beenden, dann erneut Starten",
     "launch_hung": "Hängende Session beendet — starte neu…",
     "launch_not_alive": "„{name}“ scheint nach dem Start nicht aktiv zu sein.\n\nLog: {log}\n\n{tips}",
+    "launch_failed": "Start fehlgeschlagen",
+    "launch_failed_body": "„{name}“ ist nicht gestartet.\n\n{detail}\n\nLog: {log}\n\nPrüfe: Festplatte gemountet? Installationsordner gewählt? Dann Reparieren.",
     "launch_tips_wiso": "Rezeptor → WISO → Reparieren (stellt wined3d + Qt-Startfix ein).\nErster Start kann 10–20 s dauern — Log-Tab prüfen.\nLinux-Internet bleibt aktiv; nur ein WISO-Qt-Plugin wird deaktiviert.",
     "launch_tips_default": "Beenden → erneut Starten, oder Reparieren. Log-Tab prüfen."
   },

--- a/launcher/locales/en.json
+++ b/launcher/locales/en.json
@@ -621,6 +621,8 @@
     "launch_already": "“{name}” was already running (possibly hidden) — Quit, then Launch again",
     "launch_hung": "Hung session ended — restarting…",
     "launch_not_alive": "“{name}” does not appear to be active after launch.\n\nLog: {log}\n\n{tips}",
+    "launch_failed": "Launch failed",
+    "launch_failed_body": "“{name}” did not start.\n\n{detail}\n\nLog: {log}\n\nCheck: disk mounted? Install folder selected? Then try Repair.",
     "launch_tips_wiso": "Rezeptor → WISO → Repair (sets wined3d + Qt launch fix).\nFirst start can take 10–20 s — check the Log tab.\nLinux internet stays active; only one WISO Qt plugin is disabled.",
     "launch_tips_default": "Quit → Launch again, or Repair. Check the Log tab."
   },

--- a/launcher/recipe_process.py
+++ b/launcher/recipe_process.py
@@ -768,6 +768,36 @@ class RecipeProcessOps:
                 t("dialog.launch_already", name=name),
             )
             return
+        # Immediate script failure (missing EXE / not installed) — not "not alive".
+        fail_markers = (
+            "Nicht installiert",
+            "Halo-EXE fehlt",
+            "ERROR: ",
+            "ERROR:Nicht",
+        )
+        if any(m in log_tail for m in fail_markers):
+            name = self._w._selected.meta.get("name", rid) if self._w._selected else rid
+            detail = ""
+            for line in reversed(log_tail.splitlines()):
+                s = line.strip()
+                if not s:
+                    continue
+                if s.startswith("ERROR:") or "Nicht installiert" in s or "fehlt" in s:
+                    detail = s.removeprefix("ERROR:").strip()
+                    break
+            if not detail:
+                detail = t("dialog.launch_tips_default")
+            QMessageBox.warning(
+                self._w,
+                t("dialog.launch_failed"),
+                t(
+                    "dialog.launch_failed_body",
+                    name=name,
+                    detail=detail,
+                    log=str(log_path),
+                ),
+            )
+            return
         if "Hängende unsichtbare" in log_tail and attempt == 0:
             self._w._activity("info", t("dialog.launch_hung"))
         meta = self._w._selected.meta if self._w._selected else None

--- a/tests/test_recipe_data_root_persist.bats
+++ b/tests/test_recipe_data_root_persist.bats
@@ -56,3 +56,16 @@ teardown() {
     [ "$ptr" = "$NEW" ]
     [ "$DATA_ROOT" = "$NEW" ]
 }
+
+@test "canonical RECIPE_DATA_ROOT does not wipe offline relocated pointer" {
+    # Simulate unmounted disk: pointer targets missing path; GUI falls back to canonical.
+    OFFLINE="$TMP/ssd-offline-halo"
+    printf '%s\n' "$OFFLINE" >"$CANON/data_root.path"
+    unset DATA_ROOT || true
+    export RECIPE_DATA_ROOT="$CANON"
+    export DATA_ROOT="$CANON"
+    recipe_export_env "$YML"
+    ptr="$(tr -d '\r\n' <"$CANON/data_root.path")"
+    [ "$ptr" = "$OFFLINE" ]
+    [ "$DATA_ROOT" = "$CANON" ]
+}


### PR DESCRIPTION
## Summary
- Preserve relocated \`data_root.path\` when the target mount is offline (GUI canonical fallback must not wipe it)
- Launch alive-check: show real ERROR/not-installed messages instead of “not active after launch”
- Changelog notes for 1.1.43

## Test plan
- [ ] \`bats tests/test_recipe_data_root_persist.bats\`
- [ ] Unmount SSD2 briefly: pointer stays; remount + launch Halo works
- [ ] Missing EXE shows “Start fehlgeschlagen” with log detail


Made with [Cursor](https://cursor.com)