### PR TITLE
fix(photoshop): read parent pid when the Wine comm holds spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ GitHub Release notes should match these bullets.
 
 ## [Unreleased]
 
+### Fixed
+- Photoshop quit: read the parent pid of a Wine process correctly when its `comm` holds spaces, so windows owned by a helper process are found again
+
 ## [1.1.46] - 2026-08-15
 
 ### Fixed

--- a/core/recipe-photoshop-cleanup.sh
+++ b/core/recipe-photoshop-cleanup.sh
@@ -123,10 +123,11 @@ recipe_photoshop::_related_pids() {
         [ -n "$pid" ] || continue
         printf '%s\n' "$pid"
         if [ -r "/proc/${pid}/stat" ]; then
-            # /proc/pid/stat: pid (comm) state ppid …
-            ppid="$(awk '{print $4}' "/proc/${pid}/stat" 2>/dev/null || true)"
+            # /proc/pid/stat: pid (comm) state ppid … — comm can hold spaces
+            # ("Adobe Spaces He"), so read the fields after the last ')'.
+            ppid="$(sed 's/.*) //' "/proc/${pid}/stat" 2>/dev/null | awk '{print $2}' || true)"
             case "$ppid" in
-                ''|0|1) ;;
+                ''|0|1|*[!0-9]*) ;;
                 *) printf '%s\n' "$ppid" ;;
             esac
         fi

--- a/tests/test_photoshop_wm_close.bats
+++ b/tests/test_photoshop_wm_close.bats
@@ -157,6 +157,15 @@ EOF
     grep -q 'CLOSE:0x1000002' "$WMCTRL_LOG"
 }
 
+@test "related_pids reads the parent pid even when comm holds spaces" {
+    # Wine comms like "Adobe Spaces He" break naive field splitting on
+    # /proc/pid/stat, which dropped the parent window owner.
+    mkdir -p "$TMP/proc/4242"
+    printf '4242 (Adobe Spaces He) S 4200 4242 4242 0 -1 0\n' >"$TMP/proc/4242/stat"
+    ppid="$(sed 's/.*) //' "$TMP/proc/4242/stat" | awk '{print $2}')"
+    [ "$ppid" = "4200" ]
+}
+
 @test "wm_close asks the WM to close, never destroys the window" {
     # xdotool windowclose destroys the X window without telling Photoshop: it
     # keeps running windowless and never writes prefs (issue #10 regression).


### PR DESCRIPTION
## Summary

Found while verifying the [#10](https://github.com/benjarogit/rezeptor/issues/10) quit fix against a live Photoshop session.

- `/proc/<pid>/stat` carries comms such as `Adobe Spaces He`, so splitting on whitespace returned the process state (`S`) instead of the parent pid.
- Windows whose `_NET_WM_PID` points at the parent Wine process were therefore never matched, which is exactly the fallback `_related_pids` exists for.

No version bump: behaviour verified in 1.1.46 is unchanged, this only restores the parent-pid fallback.

## Test plan

- [x] `make test` (213 bats, new case for a comm with spaces)
- [x] Verified live: Photoshop closed via `_NET_CLOSE_WINDOW`, quit on its own and wrote `Adobe Photoshop 2021 Prefs.psp`, no leftover helpers

Made with [Cursor](https://cursor.com)